### PR TITLE
fix(ci): install postgres/mysql/sqlite/ga4 extras in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies (all extras)
-        run: uv sync --frozen --dev --extra bigquery --extra s3 --extra gcs --extra metrics
+        run: uv sync --frozen --dev --extra bigquery --extra s3 --extra gcs --extra metrics --extra postgres --extra mysql --extra sqlite --extra ga4
 
       - name: Run full test suite (including slow and fuzz)
         run: |
@@ -70,7 +70,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --frozen --dev --extra bigquery --extra s3 --extra gcs --extra metrics
+        run: uv sync --frozen --dev --extra bigquery --extra s3 --extra gcs --extra metrics --extra postgres --extra mysql --extra sqlite --extra ga4
 
       - name: Install recotem
         run: uv pip install --no-deps .


### PR DESCRIPTION
## Summary

- Align `.github/workflows/nightly.yml` `uv sync` extras with `test.yml`, adding `--extra postgres --extra mysql --extra sqlite --extra ga4` to both the `slow-tests` and `slow-e2e` jobs.

## Why

PR #92 (`feat(datasource): add SQL + GA4 Data API sources`) added the SQL/GA4 data sources and updated `test.yml` to install the new driver extras, but `nightly.yml` was not updated. The nightly run on 2026-05-16 ([run 25958233827](https://github.com/codelibs/recotem/actions/runs/25958233827)) failed with **27 failed, 1651 passed** because `tests/unit/test_datasource_sql.py` tests exercise SSRF / private-host validation paths that, after #92, are reached only after `psycopg` is importable — without the `postgres` extra, `SQLSource.__init__` raises `DataSourceError: psycopg driver is required for dialect 'postgresql'` and the regex-rejection assertions fail.

The earlier failure in [run 25955560532](https://github.com/codelibs/recotem/actions/runs/25955560532) (MovieLens `input()` prompt) was independently fixed in #92 by passing `force_download=True`; this PR cleans up the second, separate regression from the same PR.

## Test plan

- [x] Locally `uv sync` with the new extras list (`postgres mysql sqlite ga4` added).
- [x] `uv run pytest tests/unit/test_datasource_sql.py --override-ini='addopts=' -q` → 124 passed.
- [ ] After merge, manually dispatch `nightly.yml` against `main` and confirm both `slow-tests` and `slow-e2e` jobs go green.