### PR TITLE
docs(readme): use demo keys in quickstart to remove keygen step

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,11 @@ artifact directory all in one place. Train a TopPop recommender from a
 60-user CSV in under a minute.
 
 ```bash
-# 1. Generate keys (once per machine). Copy the values into the exports below.
-recotem keygen --type signing --kid dev
-recotem keygen --type api     --kid dev
-
-export RECOTEM_SIGNING_KEYS="dev:<signing-plaintext>"   # used by train + serve
-export RECOTEM_API_KEYS="dev:sha256:<api-hash>"         # used by serve
-export RECOTEM_API_PLAINTEXT="<api-plaintext>"          # used by curl below
+# 1. Set demo keys. DEMO ONLY — for production, generate fresh keys with
+#    `recotem keygen --type signing` and `recotem keygen --type api`.
+export RECOTEM_SIGNING_KEYS="dev:0000000000000000000000000000000000000000000000000000000000000000"
+export RECOTEM_API_PLAINTEXT="recotem-quickstart"
+export RECOTEM_API_KEYS="dev:sha256:921281c95ab79adecf21d410f8c93d38d74b0c3c267c221c8291771de8e7c359"
 
 # 2. Train, serve
 recotem train examples/quickstart/recipe.yaml


### PR DESCRIPTION
## Summary
- Replace the two-step `recotem keygen` instructions in the README quickstart with fixed demo values (signing key of 64 hex zeros, pre-computed `sha256("recotem-quickstart")` for the API key hash) so the example is copy-paste runnable.
- Add a `DEMO ONLY` notice pointing to `recotem keygen` for real deployments.

## Why
The quickstart is meant for verifying the install works end-to-end. Asking the reader to run `recotem keygen` twice and paste the values back into env vars adds friction without teaching anything that the dedicated `recotem keygen` docs do not already cover.

## Test plan
- [ ] Run the README quickstart commands verbatim against `examples/quickstart/` and confirm `recotem train`, `recotem serve`, and the `curl /predict/top_picks` call all succeed.
- [ ] Confirm the rendered README still reads cleanly on GitHub.