### PR TITLE
docs(readme): fix quickstart demo API key to match server hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ artifact directory all in one place. Train a TopPop recommender from a
 # 1. Set demo keys. DEMO ONLY — for production, generate fresh keys with
 #    `recotem keygen --type signing` and `recotem keygen --type api`.
 export RECOTEM_SIGNING_KEYS="dev:0000000000000000000000000000000000000000000000000000000000000000"
-export RECOTEM_API_PLAINTEXT="recotem-quickstart"
-export RECOTEM_API_KEYS="dev:sha256:921281c95ab79adecf21d410f8c93d38d74b0c3c267c221c8291771de8e7c359"
+export RECOTEM_API_PLAINTEXT="recotem-quickstart-demo-key-0000"
+export RECOTEM_API_KEYS="dev:sha256:21be5c3be85b8d68123df9f9b6a26d8e307db30350ea8bcc844883e22ebcf125"
 
 # 2. Train, serve
 recotem train examples/quickstart/recipe.yaml


### PR DESCRIPTION
## Summary
The quickstart in `README.md` shipped a demo `X-API-Key` that the server rejects unconditionally, so following the quickstart end-to-end always failed with `{"detail":"Invalid API key","code":"invalid_api_key"}`. This patches the demo plaintext and hash so the example works as written.

## Changes Made
- `README.md`: replace `RECOTEM_API_PLAINTEXT="recotem-quickstart"` (18 chars) with `recotem-quickstart-demo-key-0000` (32 chars), meeting `_API_KEY_MIN_LEN = 32` enforced in `src/recotem/serving/auth.py`.
- `README.md`: replace the `RECOTEM_API_KEYS` digest with the correct `scrypt(N=2, r=8, p=1, dklen=32, salt=b"recotem.api-key.v1")` hex of the new plaintext (`21be5c3b…f125`). The previous value was a plain `sha256()` of the old plaintext, which never matches what `recotem.serving.auth._hash_api_key` computes — the `sha256:` token on the wire is a digest-family label, not the algorithm name.

## Testing
- Re-derived the digest via `recotem.serving.auth._hash_api_key("recotem-quickstart-demo-key-0000")` and confirmed it equals the new README value byte-for-byte.
- Length check: `len("recotem-quickstart-demo-key-0000") == 32`, so the `_API_KEY_MIN_LEN` guard no longer rejects it.

## Breaking Changes
None — README-only documentation fix. Operators following the quickstart will set new env values, but no code, schema, or wire format changed.

## Additional Notes
- This regression was introduced by #95 (`docs(readme): use demo keys in quickstart to remove keygen step`), which precomputed the hash with the wrong algorithm and a too-short plaintext.
- The new demo plaintext is still obviously a demo (`…-demo-key-0000`); the existing "DEMO ONLY — for production, generate fresh keys" warning above it is unchanged.