### PR TITLE
fix(ci): limit Trivy SARIF severities to CRITICAL,HIGH

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,6 +110,11 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: "CRITICAL,HIGH"
+          # Without this, `format: sarif` causes trivy-action to override
+          # TRIVY_SEVERITY to include all severities ("Building SARIF report
+          # with all severities"), which makes `exit-code: 1` fire on
+          # MEDIUM/LOW findings too — defeating the `severity` filter.
+          limit-severities-for-sarif: true
           # Skip CVEs without an upstream fix.  Slim base images frequently
           # carry HIGH OS CVEs (libcap2, ncurses-bin, libudev1, ...) that
           # have no fixed Debian version yet — gating CI on these would mean


### PR DESCRIPTION
## Summary

The `trivy vulnerability scan` job in `.github/workflows/docker.yml` was triggered by the `v2.0.0a0` tag push and failed with `exit code 1`, even though the only fixable finding was a **MEDIUM** severity CVE (`CVE-2026-45409` in `idna 3.13`).

Root cause: when `format: sarif` is used without `limit-severities-for-sarif: true`, `aquasecurity/trivy-action` overrides `TRIVY_SEVERITY` to include every severity ("Building SARIF report with all severities" in the log) so that the SARIF uploaded to the GitHub Security tab is complete. The side-effect is that `exit-code: 1` then evaluates findings of every severity — silently disabling the explicit `severity: "CRITICAL,HIGH"` input.

## Change

Add `limit-severities-for-sarif: true` to the Trivy step so that:

- The SARIF report contains only CRITICAL/HIGH findings.
- `exit-code: 1` fires only on CRITICAL/HIGH (which is the original intent).
- The fixable MEDIUM idna CVE no longer breaks tag/main builds; it should still be addressed by a regular dependency bump.

## Test plan

- [ ] CI green on this PR (the workflow change runs against the PR build).
- [ ] After merge, the next push to `main` and the next semver tag complete the `trivy vulnerability scan` job successfully.
- [ ] GitHub Security tab continues to receive SARIF uploads (only CRITICAL/HIGH now).