### PR TITLE
chore: bump version to 2.0.0a1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "recotem"
-version = "2.0.0a0"
+version = "2.0.0a1.dev0"
 description = "Recipe-driven recommender training and serving on irspack."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2130,7 +2130,7 @@ wheels = [
 
 [[package]]
 name = "recotem"
-version = "2.0.0a0"
+version = "2.0.0a1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
Bumps the project version from `2.0.0a0` to `2.0.0a1.dev0` to open the next development cycle following the `2.0.0a0` pre-release.

## Changes Made
- `pyproject.toml`: update `project.version` to `2.0.0a1.dev0`
- `uv.lock`: regenerate the `recotem` editable entry to match

## Testing
- No runtime behaviour changes; CI's lint + test suite is sufficient.

## Breaking Changes
- None.

## Additional Notes
- `.dev0` keeps this pre-release sortable below an eventual `2.0.0a1` tag (PEP 440).
- No source or dependency changes are included.