### PR TITLE
fix(serve): allow-list embedded recommender internals so IALS/KNN/SVD artifacts load

### DIFF
--- a/docs/data-sources/bigquery.md
+++ b/docs/data-sources/bigquery.md
@@ -6,11 +6,19 @@
 pip install "recotem[bigquery]"
 ```
 
-Without this extra, `recotem train` exits with:
+Without this extra, `recotem train` exits with exit code 3 (`DataSourceError`).
+The `bigquery` extra pulls in two packages that are checked independently, so
+the message names whichever is missing first:
 
 ```
-DataSourceError: BigQuery source requires 'recotem[bigquery]'. Install with: pip install "recotem[bigquery]"
+DataSourceError: google-cloud-bigquery is required for BigQuerySource. Install it with: pip install recotem[bigquery]
 ```
+
+```
+DataSourceError: db-dtypes is required for BigQuerySource. Install it with: pip install recotem[bigquery]
+```
+
+Installing `recotem[bigquery]` resolves both.
 
 ## Authentication
 
@@ -135,7 +143,7 @@ schema:
 | Permission denied on dataset | 3 | `DataSourceError: Access Denied: Dataset my-project:analytics_123456789` |
 | Query syntax error | 3 | `DataSourceError: Syntax error: ...` |
 | Column missing after query | 2 | `RecipeError: column 'item_id' not found in query result` |
-| Extra not installed | 3 | `DataSourceError: BigQuery source requires 'recotem[bigquery]'` |
+| Extra not installed | 3 | `DataSourceError: google-cloud-bigquery is required for BigQuerySource` (or `db-dtypes ...`) |
 
 All BigQuery exceptions are wrapped in `DataSourceError` and produce exit 3. The full BigQuery error message is included in the stderr JSON line.
 

--- a/docs/data-sources/bigquery.md
+++ b/docs/data-sources/bigquery.md
@@ -98,9 +98,84 @@ YAML quoting matters: `lookback_days: 30` is `INT64`, `lookback_days: "30"` is `
 
 GA4 exports to BigQuery using date-sharded tables named `events_YYYYMMDD`. Use `_TABLE_SUFFIX` to filter by date range without a full table scan.
 
+### Where `item_id` comes from
+
+Recotem reads an already-fetched DataFrame and expects the columns named in
+`schema` to exist verbatim — there is **no recipe-level field for regex,
+expressions, or derived columns**. Any extraction or reshaping must therefore
+happen **inside the SQL query** using BigQuery functions such as
+`REGEXP_EXTRACT`. The query below produces three columns (`user_id`, `item_id`,
+`ts`) that map directly onto `schema`.
+
+### Recommended: derive `item_id` from `page_location`
+
+`page_location` (the page URL) is recorded on every `page_view` event in any GA4
+export with **no extra tagging or GTM configuration**, which makes it the most
+portable signal for building a "users who viewed this also viewed…" recommender
+straight from raw access logs. The simplest, fully general choice is to use the
+URL **path** as the item:
+
 ```yaml
 source:
   type: bigquery
+  project: my-project
+  query: |
+    SELECT
+      user_pseudo_id                                                    AS user_id,
+      REGEXP_EXTRACT(
+        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+        r'^https?://[^/]+([^?#]*)'                       -- path only; drop host, query, fragment
+      )                                                                 AS item_id,
+      TIMESTAMP_MICROS(event_timestamp)                                 AS ts
+    FROM
+      `my-project.analytics_123456789.events_*`
+    WHERE
+      _TABLE_SUFFIX BETWEEN
+        FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+      AND event_name = 'page_view'
+```
+
+```yaml
+schema:
+  user_column: user_id
+  item_column: item_id
+  time_column: ts
+cleansing:
+  drop_null_ids: true   # REGEXP_EXTRACT returns NULL on no match — drop those rows
+```
+
+This covers a rolling 30-day window with no parameter binding (dates are
+computed in SQL) and treats each distinct path as one item.
+
+If your URLs embed a **stable identifier** (product / article / content ID) you
+can extract just that ID for a tighter, slug-independent item space. Match on a
+delimiter so unrelated digits in the URL (e.g. the `2026` in a `/2026/04/12/`
+date path) are not picked up:
+
+```sql
+-- .../articles/12345-some-title       -> "12345"  (numeric ID after a path segment)
+REGEXP_EXTRACT(page_location, r'/articles/(\d+)')
+
+-- .../some-title-(A12B)/              -> "A12B"   (4-char alphanumeric ID in parentheses;
+--                                                  also matches full-width （ ）)
+REGEXP_EXTRACT(page_location, r'[（(]([0-9A-Z]{4})[）)]')
+```
+
+Adapt the pattern to your own URL scheme. RE2 (BigQuery's engine) supports
+`\d`, character classes, and UTF-8 literals such as full-width parentheses.
+
+### Alternative: a custom event parameter
+
+If you already emit a dedicated identifier as a custom event parameter (this
+requires GA4 / GTM configuration on the site), read it from `event_params`
+instead. Replace the type accessor (`value.int_value` /
+`value.string_value`) to match how the parameter was sent:
+
+```yaml
+source:
+  type: bigquery
+  project: my-project
   query: |
     SELECT
       user_pseudo_id                                                   AS user_id,
@@ -118,22 +193,41 @@ source:
       AND (SELECT value.int_value
              FROM UNNEST(event_params)
             WHERE key = 'article_id') IS NOT NULL
-  project: my-project
 ```
 
-This query:
-- Covers the rolling 30-day window with no parameter binding needed (dates are computed in SQL).
-- Filters to `select_content` events with a non-null `article_id`.
-- Produces three columns: `user_id`, `item_id`, `ts`.
+## Serving and recommending
 
-Map the output columns in `schema`:
+Once `recotem train` has written a signed artifact, point `recotem serve` at a
+directory of recipes and call the recipe's `:recommend` endpoint. The verb in
+the path is the recipe `name`:
 
-```yaml
-schema:
-  user_column: user_id
-  item_column: item_id
-  time_column: ts
+```bash
+curl -X POST http://localhost:8080/v1/recipes/{name}:recommend \
+     -H "X-API-Key: <plaintext-api-key>" \
+     -H "Content-Type: application/json" \
+     -d '{"user_id": "<a user value seen during training>", "limit": 10}'
 ```
+
+```json
+{
+  "request_id": "…",
+  "recipe": "{name}",
+  "model_version": "sha256:…",
+  "items": [
+    {"item_id": "/some/page-path", "score": 0.0469},
+    {"item_id": "/another/page",   "score": 0.0371}
+  ]
+}
+```
+
+- `user_id` is whatever you mapped in `schema.user_column` (for GA4 this is
+  commonly `user_pseudo_id`). A user not seen during training returns
+  `404 UNKNOWN_USER`.
+- To get item-to-item recommendations without a user, call `:recommend-related`
+  with a `seed_items` list of known `item_id` values.
+- Without `RECOTEM_API_KEYS` configured the server binds to loopback and accepts
+  unauthenticated requests; see [getting-started](../getting-started.md) and
+  [operations](../operations.md) for serving setup and API-key configuration.
 
 ## Errors and exit codes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -197,6 +197,15 @@ irspack.recommenders.rp3.RP3betaRecommender
 irspack.recommenders.dense_slim.DenseSLIMRecommender
 irspack.recommenders.truncsvd.TruncatedSVDRecommender
 irspack.recommenders.bpr.BPRFMRecommender
+irspack.recommenders.ials.IALSTrainer
+irspack.recommenders.ials.IALSConfigScaling
+irspack.recommenders._ials_core.IALSTrainer
+irspack.recommenders._ials_core.IALSModelConfig
+irspack.recommenders._ials_core.IALSSolverConfig
+irspack.recommenders._ials_core.LossType
+irspack.recommenders._ials_core.SolverType
+irspack.recommenders.knn.FeatureWeightingScheme
+sklearn.decomposition._truncated_svd.TruncatedSVD
 numpy.ndarray
 numpy.dtype
 numpy.core.multiarray._reconstruct
@@ -220,7 +229,13 @@ builtins.frozenset
 collections.OrderedDict
 ```
 
-This list is frozen per Recotem release.
+This list is frozen per Recotem release. It includes the `*Recommender`
+classes **and** the trainer, config, enum, and scikit-learn estimator objects
+those recommenders embed as attributes (e.g. `IALSTrainer`, `LossType`,
+`FeatureWeightingScheme`, scikit-learn's `TruncatedSVD`). A trained artifact is
+a single pickle graph: if any embedded class is absent the artifact is rejected
+at serve time even though training and signing succeeded, so the list must
+cover the full object graph, not just the entry-point recommender.
 
 In addition to the FQCN list, classes whose defining module sits under
 one of the following narrow prefixes are permitted via the prefix

--- a/src/recotem/artifact/signing.py
+++ b/src/recotem/artifact/signing.py
@@ -69,6 +69,33 @@ _ALLOWED_CLASSES: frozenset[tuple[str, str]] = frozenset(
         ("irspack.recommenders.dense_slim", "DenseSLIMRecommender"),
         ("irspack.recommenders.truncsvd", "TruncatedSVDRecommender"),
         ("irspack.recommenders.bpr", "BPRFMRecommender"),
+        # irspack recommender *internals*.  A trained recommender is not a
+        # single object: the pickle graph also embeds the trainer, config, and
+        # enum instances the recommender holds as attributes.  These FQCNs are
+        # NOT covered by listing the top-level *Recommender class, so omitting
+        # them makes the artifact unloadable at serve time even though training
+        # + signing succeeded (the recommender pickles fine, but SafeUnpickler
+        # rejects the embedded class on load).  Enumerated by training each
+        # algorithm and recording every find_class the payload triggers; see
+        # tests/unit/test_artifact_signing.py::test_<algo>_artifact_roundtrip.
+        #
+        # IALS — IALSRecommender embeds an IALSTrainer plus its model/solver
+        # config dataclasses and Loss/Solver enums (defined in the compiled
+        # _ials_core extension), and an IALSConfigScaling enum.
+        ("irspack.recommenders.ials", "IALSTrainer"),
+        ("irspack.recommenders.ials", "IALSConfigScaling"),
+        ("irspack.recommenders._ials_core", "IALSTrainer"),
+        ("irspack.recommenders._ials_core", "IALSModelConfig"),
+        ("irspack.recommenders._ials_core", "IALSSolverConfig"),
+        ("irspack.recommenders._ials_core", "LossType"),
+        ("irspack.recommenders._ials_core", "SolverType"),
+        # CosineKNN — stores the feature-weighting scheme as an enum.
+        ("irspack.recommenders.knn", "FeatureWeightingScheme"),
+        # TruncatedSVD — irspack delegates to scikit-learn's TruncatedSVD,
+        # whose fitted estimator is embedded in the recommender.  Its numpy
+        # array attributes are already covered by the numpy.* prefix list; only
+        # the estimator class itself needs an explicit FQCN entry.
+        ("sklearn.decomposition._truncated_svd", "TruncatedSVD"),
         # numpy.  Both numpy 1.x (numpy.core.*) and numpy 2.x
         # (numpy._core.*) reconstruction helpers are pinned explicitly
         # — these are the FQCNs every artifact references via the

--- a/tests/integration/test_serve_predict_e2e.py
+++ b/tests/integration/test_serve_predict_e2e.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from recotem.config import ApiKeyEntry
@@ -323,6 +324,134 @@ def test_train_then_serve_full_artifact_roundtrip(tmp_path: Path) -> None:
     # Each recommendation is a (item_id, score) pair.
     assert isinstance(recs[0][0], str)
     assert isinstance(recs[0][1], float)
+
+
+# Every algorithm recotem advertises (see training.algorithms.SUPPORTED_CLASS_NAMES).
+_ROUNDTRIP_ALGOS = [
+    "TopPop",
+    "IALS",
+    "CosineKNN",
+    "RP3beta",
+    "DenseSLIM",
+    "TruncatedSVD",
+    "BPRFM",
+]
+
+
+def _irspack_has_recommender(class_name: str) -> bool:
+    """True when the installed irspack build exposes ``class_name``.
+
+    Some recommenders (e.g. BPRFMRecommender) are gated behind optional irspack
+    dependencies such as ``lightfm``; when the dependency is absent irspack does
+    not export the class and recotem cannot train it.
+    """
+    import irspack.recommenders as irspack_recommenders
+
+    import recotem.training._compat  # noqa: F401  (installs IPython stub)
+
+    return hasattr(irspack_recommenders, class_name)
+
+
+def _make_clustered_synthetic_csv(tmp_path: Path) -> Path:
+    """Deterministic, non-degenerate interaction matrix for cross-algorithm tests.
+
+    A fully-dense grid (every user interacts with every item) is rank-deficient
+    and makes matrix-factorisation algorithms emit divide-by-zero warnings that
+    the warnings-as-error suite turns into failures.  Instead lay out users in
+    overlapping clusters with a few per-user idiosyncratic items, giving a matrix
+    with real low-rank structure that every algorithm can factorise cleanly.
+    """
+    n_users, n_items, n_clusters, band = 60, 40, 6, 12
+    pairs: set[tuple[str, str]] = set()
+    for u in range(n_users):
+        cluster = u % n_clusters
+        for k in range(band):
+            pairs.add(
+                (f"u{u}", f"i{(cluster * (n_items // n_clusters) + k) % n_items}")
+            )
+        # idiosyncratic items so users within a cluster are not identical
+        pairs.add((f"u{u}", f"i{(u * 7) % n_items}"))
+        pairs.add((f"u{u}", f"i{(u * 13 + 3) % n_items}"))
+    rows = ["user_id,item_id"]
+    rows.extend(f"{u},{i}" for u, i in sorted(pairs))
+    csv_file = tmp_path / "clustered.csv"
+    csv_file.write_text("\n".join(rows) + "\n")
+    return csv_file
+
+
+# irspack's TruncatedSVD tunes n_components over [4, 512]; on a small item
+# catalogue Optuna may pick a value >= n_items, which irspack clamps with a
+# UserWarning.  The suite runs warnings-as-error, but production training does
+# not, so silence only this specific clamp warning rather than aborting the trial.
+@pytest.mark.filterwarnings("ignore:n_components >= than:UserWarning")
+@pytest.mark.parametrize("algo", _ROUNDTRIP_ALGOS)
+def test_every_algorithm_artifact_serve_roundtrip(tmp_path: Path, algo: str) -> None:
+    """Each supported algorithm must train -> sign -> SafeUnpickler-load.
+
+    Regression for the FQCN allow-list: a trained recommender is a pickle graph
+    that embeds not just the top-level ``*Recommender`` class but the trainer,
+    config dataclasses, enums, and (for TruncatedSVD) the scikit-learn estimator
+    it holds as attributes.  If any of those embedded classes is missing from
+    ``_ALLOWED_CLASSES`` the artifact is unloadable at serve time even though
+    training + signing succeeded — the failure mode that left IALS models
+    permanently stuck in ``RECIPE_UNAVAILABLE`` (503) at the serve layer.
+    """
+    from recotem.artifact.io import read_artifact
+    from recotem.artifact.signing import KeyRing, unpickle_payload
+    from recotem.datasource.csv import CSVConfig
+    from recotem.recipe.models import (
+        OutputConfig,
+        Recipe,
+        SchemaConfig,
+        SplitConfig,
+        TrainingConfig,
+    )
+    from recotem.training._compat import IDMappedRecommender
+    from recotem.training.algorithms import resolve_algorithm_name
+    from recotem.training.pipeline import run_training
+
+    class_name = resolve_algorithm_name(algo)
+    if not _irspack_has_recommender(class_name):
+        pytest.skip(
+            f"installed irspack build lacks {class_name} "
+            "(optional dependency not installed)"
+        )
+
+    csv_file = _make_clustered_synthetic_csv(tmp_path)
+    artifact_path = str(tmp_path / f"{algo}.recotem")
+
+    recipe = Recipe(
+        name=f"roundtrip-{algo}",
+        source=CSVConfig(type="csv", path=str(csv_file)),
+        schema=SchemaConfig(user_column="user_id", item_column="item_id"),
+        training=TrainingConfig(
+            algorithms=[algo],
+            n_trials=2,
+            cutoff=5,  # must be < n_items to avoid irspack ValueError
+            split=SplitConfig(scheme="random", heldout_ratio=0.2, seed=0),
+        ),
+        output=OutputConfig(path=artifact_path, versioning="always_overwrite"),
+    )
+
+    kr = KeyRing("dev:" + ("0" * 64))
+    result = run_training(
+        recipe,
+        key_ring=kr,
+        signing_key="dev",
+        no_lock=True,
+        dev_allow_unsigned=True,
+        quiet=True,
+    )
+    assert result is not None, f"{algo}: run_training returned None (zero score?)"
+    assert resolve_algorithm_name(result.best_class) == class_name
+
+    # The serve-side load path: HMAC verify, then SafeUnpickler with the FQCN
+    # allow-list.  This must NOT raise ArtifactError("class not allowed: ...").
+    _, payload_bytes = read_artifact(result.artifact_path, kr)
+    recommender = unpickle_payload(payload_bytes)
+    assert isinstance(recommender, IDMappedRecommender)
+    assert len(recommender.user_ids) > 0
+    assert len(recommender.item_ids) > 0
 
 
 def test_train_append_sha_then_serve_resolves_pointer(tmp_path: Path) -> None:

--- a/tests/unit/test_artifact_signing.py
+++ b/tests/unit/test_artifact_signing.py
@@ -722,6 +722,36 @@ def test_idmap_neutral_fqcn_in_allow_list() -> None:
     )
 
 
+def test_recommender_internal_fqcns_in_allow_list() -> None:
+    """Embedded recommender internals must be allow-listed for serve to load.
+
+    A trained recommender pickle embeds the trainer/config/enum/estimator
+    objects it holds as attributes; these are distinct FQCNs from the top-level
+    ``*Recommender`` class.  Omitting any of them makes the artifact unloadable
+    at serve time (``class not allowed: ...``) even though train + sign
+    succeeded.  See test_serve_predict_e2e.test_every_algorithm_artifact_serve_roundtrip
+    for the end-to-end guard; this is the cheap, always-run assertion.
+    """
+    from recotem.artifact.signing import _ALLOWED_CLASSES
+
+    required = {
+        # IALS internals
+        ("irspack.recommenders.ials", "IALSTrainer"),
+        ("irspack.recommenders.ials", "IALSConfigScaling"),
+        ("irspack.recommenders._ials_core", "IALSTrainer"),
+        ("irspack.recommenders._ials_core", "IALSModelConfig"),
+        ("irspack.recommenders._ials_core", "IALSSolverConfig"),
+        ("irspack.recommenders._ials_core", "LossType"),
+        ("irspack.recommenders._ials_core", "SolverType"),
+        # CosineKNN internals
+        ("irspack.recommenders.knn", "FeatureWeightingScheme"),
+        # TruncatedSVD delegates to scikit-learn's estimator
+        ("sklearn.decomposition._truncated_svd", "TruncatedSVD"),
+    }
+    missing = sorted(required - _ALLOWED_CLASSES)
+    assert not missing, f"FQCNs missing from _ALLOWED_CLASSES: {missing}"
+
+
 def test_kid_bytes_tampered_rejected() -> None:
     """Replacing the kid field bytes in a valid artifact (keeping same length)
     must cause HMAC verification to fail with ArtifactError.


### PR DESCRIPTION
## Summary

A trained recommender is a single pickle graph: the top-level `*Recommender` object embeds the **trainer, config dataclasses, enums, and (for TruncatedSVD) the scikit-learn estimator** it holds as attributes. The serve-side `SafeUnpickler` FQCN allow-list only listed the entry-point `*Recommender` classes, so artifacts for several algorithms could not be deserialized at serve time — `class not allowed: ...` — **even though `recotem train` succeeded and signed them**. Affected recipes stayed permanently in `RECIPE_UNAVAILABLE` (HTTP 503) and never loaded.

Confirmed affected (by training each algorithm and recording every class the payload references):

| Algorithm | Missing embedded FQCNs |
|---|---|
| IALS | `IALSTrainer`, `IALSConfigScaling`, and `_ials_core` `IALSTrainer` / `IALSModelConfig` / `IALSSolverConfig` / `LossType` / `SolverType` |
| CosineKNN | `irspack.recommenders.knn.FeatureWeightingScheme` |
| TruncatedSVD | `sklearn.decomposition._truncated_svd.TruncatedSVD` |
| TopPop, RP3beta, DenseSLIM | none (already loadable) |

IALS is irspack's primary collaborative-filtering algorithm, so this made the most useful model type unservable.

## Changes

### Fix
- **`src/recotem/artifact/signing.py`** — add the embedded internal classes above to `_ALLOWED_CLASSES`, grouped and commented per algorithm.

### Tests
- **`tests/integration/test_serve_predict_e2e.py`** — parametrized `train → sign → SafeUnpickler-load` roundtrip across every advertised algorithm, on a deterministic clustered synthetic dataset (non-degenerate so matrix-factorisation algorithms factorise cleanly). Guards against future irspack/sklearn layout changes.
- **`tests/unit/test_artifact_signing.py`** — cheap always-run assertion that the internal FQCNs are present in the allow-list.

### Docs
- **`docs/security.md`** — extend the documented allow-list and explain why the full object graph (not just the entry-point recommender) must be covered.
- **`docs/data-sources/bigquery.md`**:
  - Correct the missing-extra error message to match the actual wording, and document the separate `db-dtypes` check.
  - Note that recotem has no recipe-level regex/derived-column feature — reshaping must happen in the SQL query (`REGEXP_EXTRACT`).
  - Lead the GA4 section with deriving `item_id` from `page_location` (works on raw GA4 access logs with no extra tagging): URL path as item, plus `REGEXP_EXTRACT` patterns for a stable embedded ID with an anchoring caveat. Keep the custom-event-parameter approach as an alternative.
  - Add a "Serving and recommending" section with a `:recommend` curl example, response shape, unknown-user behavior, and `:recommend-related`.

## Note on BPRFM

`BPRFMRecommender` is gated behind irspack's optional `lightfm` dependency, which is not part of recotem's pinned deps; the installed irspack build does not expose the class, so it cannot be trained (and thus cannot produce a servable artifact) in the default install. The roundtrip test auto-skips it when irspack lacks the class. The allow-list entry is retained for installs that add `lightfm`. (Pre-existing behavior — out of scope for this fix, flagged for awareness.)

## Verification

- `uv run pytest tests` → 1792 passed, 1 skipped (BPRFM), 4 deselected (slow).
- `uv run ruff check src tests` / `ruff format --check` → clean.
- End-to-end: trained an IALS model, served it, and confirmed `/v1/health` → `loaded:1` and `:recommend` → 200 with personalized scores (previously 503).