### PR TITLE
docs(skills): add create-recommendation-model skill

### DIFF
--- a/.claude/skills/create-recommendation-model/SKILL.md
+++ b/.claude/skills/create-recommendation-model/SKILL.md
@@ -1,20 +1,10 @@
 ---
 name: create-recommendation-model
 description: >-
-  Create and verify a recotem recommendation model end to end — decide what
-  counts as a user–item interaction, gather the data-source connection details,
-  write a recipe, validate it (a cost-free dry run for query sources), estimate
-  the scan/row volume, train the model, inspect the signed artifact, and
-  optionally serve it and confirm the recommend API with curl. Use this skill
-  whenever the user wants to build, train, or generate a recommender or recotem
-  model from any interaction data — web/access logs, purchases, ratings, plays,
-  clicks — held in BigQuery (GA4 export or a custom dataset), CSV, Parquet, or a
-  SQL database, or wants to author a recipe for a new source or check that a
-  trained model actually returns recommendations. Triggers even when the user
-  only says "make a model from this GA4 data", "train a recommender on our
-  purchase log", or "see if the recommend endpoint returns anything". Prefer this
-  skill over ad-hoc commands so the runtime, cost, and privacy rules below always
-  apply.
+  Create, train, and verify a recotem recommendation model from interaction data
+  (access logs, purchases, ratings) in BigQuery, CSV, Parquet, or SQL. Use when
+  building or training a recommender, authoring a recipe for a new data source,
+  or checking that the recommend API returns results.
 ---
 
 # Create a recommendation model (recotem)

--- a/.claude/skills/create-recommendation-model/SKILL.md
+++ b/.claude/skills/create-recommendation-model/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: create-recommendation-model
+description: >-
+  Create and verify a recotem recommendation model end to end — decide what
+  counts as a user–item interaction, gather the data-source connection details,
+  write a recipe, validate it (a cost-free dry run for query sources), estimate
+  the scan/row volume, train the model, inspect the signed artifact, and
+  optionally serve it and confirm the recommend API with curl. Use this skill
+  whenever the user wants to build, train, or generate a recommender or recotem
+  model from any interaction data — web/access logs, purchases, ratings, plays,
+  clicks — held in BigQuery (GA4 export or a custom dataset), CSV, Parquet, or a
+  SQL database, or wants to author a recipe for a new source or check that a
+  trained model actually returns recommendations. Triggers even when the user
+  only says "make a model from this GA4 data", "train a recommender on our
+  purchase log", or "see if the recommend endpoint returns anything". Prefer this
+  skill over ad-hoc commands so the runtime, cost, and privacy rules below always
+  apply.
+---
+
+# Create a recommendation model (recotem)
+
+Produce a working recotem model from a data source and prove it serves
+recommendations. The pipeline is source-agnostic:
+
+**model interactions → choose source → write recipe → validate → estimate
+volume → train → inspect → (optional) serve + curl**
+
+`train` and `serve` communicate only through the signed artifact file, so each
+half can be run and verified independently.
+
+The data-source-specific parts (what to ask the user, the `source:` block, how
+to shape `item_id`, and cost characteristics) live in `references/`. Read the
+one matching the user's source in Step 1 — do not load all of them.
+
+## What counts as an interaction
+
+recotem (via irspack) trains **implicit-feedback** recommenders from a table of
+interactions, each row a single positive signal:
+
+| Column (`schema`) | Meaning | Required |
+|---|---|---|
+| `user_column` | who acted (e.g. `user_pseudo_id`, `customer_id`) | yes |
+| `item_column` | what they acted on (page, product, video, article) | yes |
+| `time_column` | when (used by time-based splits) | optional but recommended |
+
+The *domain* varies — page views in access logs, line items in a purchase log,
+song plays, clicks — but they all reduce to (user, item, [time]). Decide with
+the user **what counts as a positive interaction**: e.g. `event_name =
+'purchase'`, a rating `>= 4`, or any `page_view`. Each retained row is treated
+as one positive; aggregate or dedup upstream/in-query if the raw data has many
+repeats and you do not want them weighted by frequency (the `cleansing.dedup`
+policy can collapse exact (user, item) repeats).
+
+## Non-negotiables
+
+- **Pick the recotem runtime: installed first, source fallback.** Prefer an
+  installed `recotem` (the production-representative path). Fall back to running
+  from a source checkout via `uv` when there is no installed package — and force
+  the source path when you are intentionally verifying changes to recotem's own
+  code:
+
+  ```bash
+  if command -v recotem >/dev/null 2>&1; then R="recotem"; else R="uv run recotem"; fi
+  # when iterating on recotem itself: R="uv run recotem"
+  ```
+
+  Use `$R ...` for every command below. Never invoke bare `pip`/`python` in a
+  `uv`-managed checkout — use `uv run python` for ad-hoc scripts.
+
+- **Keep secrets and private identifiers out of anything committed.** GCP
+  project IDs, dataset/DB names, DSNs, service-account keys, signing/API keys,
+  internal URLs, and concrete user/item IDs are private. Put working recipes in
+  a scratch directory (not the repo), keep credentials in env vars (the SQL
+  source reads its DSN from an env var by design; a BigQuery `project` can use
+  `${RECOTEM_RECIPE_GCP_PROJECT}`), and never paste these values into commit
+  messages, PR descriptions, or version-controlled files.
+
+- **Validate before you spend, and estimate volume before the real run.** For
+  query sources (BigQuery/SQL), `validate` is a free dry run — always run it
+  first. Keep the date window / row count small while iterating.
+
+## Step 0 — Environment
+
+```bash
+# choose $R as above, then:
+$R keygen --type signing
+export RECOTEM_SIGNING_KEYS="<kid>:<hex64>"   # from the keygen env_entry line
+```
+
+Both `train` and `serve` require a signing key and fail closed without one. The
+keys you generate here are throwaway dev keys — generate fresh keys for any real
+deployment. Source-specific auth (BigQuery ADC, SQL DSN) is covered in the
+reference for that source.
+
+## Step 1 — Choose the data source and read its reference
+
+Pick the source, then read the matching reference and gather the inputs it lists
+**before** writing the recipe. The questions genuinely differ per source.
+
+| Source | Reference | You will gather |
+|---|---|---|
+| BigQuery — GA4 export **or** a custom dataset | `references/bigquery.md` | project, table, date range, how `item_id` is encoded, ADC/IAM |
+| CSV or Parquet file (local / S3 / GCS / Azure / HTTP) | `references/files.md` | path + scheme, column names, delimiter/sha256 |
+| SQL database (Postgres / MySQL / SQLite) | `references/sql.md` | DSN env var, query, row volume |
+| Custom source plugin | see `docs/plugin-authoring.md` | the plugin's own config fields |
+
+## Step 2 — Write the recipe (in a scratch directory)
+
+Write the recipe outside the repo. The `source:` block comes from the reference;
+the rest is common:
+
+```yaml
+name: my_reco                      # becomes the /v1/recipes/{name}:* verb
+source:
+  # << from references/<source>.md >>
+schema:
+  user_column: user_id
+  item_column: item_id
+  time_column: ts                  # omit if the source has no timestamp
+cleansing:
+  drop_null_ids: true              # drop rows with a null user/item id
+  dedup: keep_last                 # collapse exact (user,item) repeats
+  min_rows: 10
+  min_users: 2
+  min_items: 2
+training:
+  algorithms: [TopPop, IALS]       # Optuna picks the best; see project CLAUDE.md for the full list
+  metric: ndcg
+  cutoff: 10
+  n_trials: 6
+  split:
+    scheme: time_user
+    heldout_ratio: 0.3
+    test_user_ratio: 1.0
+    seed: 42
+output:
+  path: /abs/path/scratch/my_reco.recotem
+  versioning: always_overwrite     # only always_overwrite | append_sha are valid
+```
+
+Recipe gotchas that bite the first time:
+
+- `output.versioning` accepts **only** `always_overwrite` or `append_sha`
+  (there is no `none`).
+- **There is no recipe-level regex or derived-column feature.** `schema.*` are
+  plain column names. Any extraction/derivation of `item_id` (e.g. pulling an ID
+  out of a URL) must happen **in the source query** (BigQuery/SQL) or **upstream**
+  when producing a CSV/Parquet file. The reference shows the idiom for the
+  source.
+- For query sources, `${...}` expansion is restricted to `RECOTEM_RECIPE_*` and
+  never applied inside the query — use the source's native bind parameters, not
+  string interpolation.
+
+## Step 3 — Validate
+
+```bash
+$R validate /abs/path/scratch/my_reco.yaml
+```
+
+What `validate` checks depends on the source: BigQuery runs a free dry run (ADC
+auth + query syntax + parameter types, no billing); SQL probes connectivity and
+the statement; CSV/Parquet check that the path exists and is readable. Fix any
+error here before training.
+
+## Step 4 — Estimate volume before the real run
+
+Right-size cost/memory before `train` actually pulls data. The mechanics are
+source-specific (BigQuery scan bytes via a manual dry run; SQL/file row volume
+and the `RECOTEM_MAX_SQL_ROWS` / download caps) — see the **Cost / volume**
+section of the source's reference. Keep the window small while iterating.
+
+## Step 5 — Train
+
+```bash
+$R train /abs/path/scratch/my_reco.yaml
+```
+
+**Watch the data shape, not just exit 0.** Collaborative filtering needs users
+with **more than one interaction**. If almost every user has a single
+interaction (common in raw web logs — one visit, one item), every trial scores 0
+and training aborts with `zero_score` (exit 4). This is correct behavior, not a
+bug. To get a trainable model, restrict to users with multiple distinct items
+(in the query for BigQuery/SQL, or upstream for files):
+
+```sql
+WITH ev AS ( /* user_id, item_id, ts ... */ ),
+     multi AS (
+       SELECT user_id FROM ev WHERE item_id IS NOT NULL
+       GROUP BY user_id HAVING COUNT(DISTINCT item_id) >= 2
+     )
+SELECT ev.* FROM ev JOIN multi USING (user_id) WHERE ev.item_id IS NOT NULL
+```
+
+On success the log reports `train_done` with `best_class`, `best_score`, and
+`n_users`/`n_items` — sanity-check those counts.
+
+## Step 6 — Inspect the artifact
+
+```bash
+$R inspect /abs/path/scratch/my_reco.recotem
+```
+
+Verifies the HMAC (`HMAC: OK`) and prints the header (`best_class`,
+`best_params`, `best_score`, `data_stats`, versions) without deserializing the
+payload.
+
+## Step 7 (optional) — Serve and confirm with curl
+
+Do this when the user wants to see the recommend API return results.
+
+```bash
+$R keygen --type api                      # note the plaintext AND the env_entry
+export RECOTEM_API_KEYS="<kid>:sha256:<hex64>"
+mkdir -p /abs/path/scratch/recipes
+cp /abs/path/scratch/my_reco.yaml /abs/path/scratch/recipes/   # serve scans *.yaml
+export RECOTEM_HOST=127.0.0.1 RECOTEM_PORT=8099
+$R serve --recipes /abs/path/scratch/recipes &
+```
+
+The `--recipes` directory holds **recipe YAMLs**, not artifacts; serve reads each
+recipe's `output.path` to locate its artifact. `:recommend` needs a `user_id`
+seen during training; `:recommend-related` only needs a known `item_id`.
+
+```bash
+KEY="<plaintext from keygen --type api>"
+BASE="http://127.0.0.1:8099"
+
+curl -s "$BASE/v1/health"                  # expect {"status":"ok","total":1,"loaded":1}
+
+curl -s -X POST "$BASE/v1/recipes/my_reco:recommend" \
+  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
+  -d '{"user_id": "<known user>", "limit": 5}'
+
+curl -s -X POST "$BASE/v1/recipes/my_reco:recommend-related" \
+  -H "X-API-Key: $KEY" -H "Content-Type: application/json" \
+  -d '{"seed_items": ["<known item>"], "limit": 5}'
+```
+
+Behaviors that confirm correct wiring: a scored `items` array on `200`; unknown
+user → `404 UNKNOWN_USER`; missing `X-API-Key` → `401 MISSING_API_KEY`. With
+`RECOTEM_API_KEYS` unset, serve binds to loopback and skips auth. Stop with
+`pkill -f "recotem serve"`.
+
+## Troubleshooting (exit codes and common failures)
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Exit 4 `zero_score` | Too few multi-interaction users — filter to users with ≥2 distinct items (Step 5). |
+| Exit 2, `output.versioning ... pattern` | Use `always_overwrite` or `append_sha`. |
+| Exit 3 `DataSourceError` on auth | Source credentials missing — see the source reference (BigQuery ADC / SQL DSN env var). |
+| `Query parameter '@x' has type STRING ... differs from INT64` | YAML quoting — `30` is INT64, `"30"` is STRING. |
+| Exit 3 `...is required for <Source>` | Install the extra: `uv sync --all-extras` (dev) or `pip install "recotem[<extra>]"`. |
+| Serve health `degraded`, `:recommend` → 503 `RECIPE_UNAVAILABLE` | Artifact failed to load — check the serve log; ensure the signing key matches and the artifact deserializes. |
+
+See the CLI exit-code table and algorithm list in the project `CLAUDE.md`, and
+`docs/data-sources/` for the full per-source reference.

--- a/.claude/skills/create-recommendation-model/SKILL.md
+++ b/.claude/skills/create-recommendation-model/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: create-recommendation-model
 description: >-
-  Create, train, and verify a recotem recommendation model from interaction data
-  (access logs, purchases, ratings) in BigQuery, CSV, Parquet, or SQL. Use when
-  building or training a recommender, authoring a recipe for a new data source,
-  or checking that the recommend API returns results.
+  Create, train, and verify a recotem recommendation model from BigQuery, CSV,
+  Parquet, or SQL data.
 ---
 
 # Create a recommendation model (recotem)

--- a/.claude/skills/create-recommendation-model/SKILL.md
+++ b/.claude/skills/create-recommendation-model/SKILL.md
@@ -67,9 +67,18 @@ policy can collapse exact (user, item) repeats).
   query sources (BigQuery/SQL), `validate` is a free dry run — always run it
   first. Keep the date window / row count small while iterating.
 
-## Step 0 — Environment
+## Step 0 — Environment and working directory
+
+**Ask the user where the recipe and model artifact should live** — the working
+directory. Everything this skill writes (the `recipe.yaml`, the `.recotem`
+artifact, and the serve `recipes/` dir) goes there. Default to a scratch
+location outside the repo so private values never land in version control; let
+the user override it.
 
 ```bash
+WORKDIR="<the directory the user chose>"   # e.g. ~/recotem-work
+mkdir -p "$WORKDIR"
+
 # choose $R as above, then:
 $R keygen --type signing
 export RECOTEM_SIGNING_KEYS="<kid>:<hex64>"   # from the keygen env_entry line
@@ -92,10 +101,10 @@ Pick the source, then read the matching reference and gather the inputs it lists
 | SQL database (Postgres / MySQL / SQLite) | `references/sql.md` | DSN env var, query, row volume |
 | Custom source plugin | see `docs/plugin-authoring.md` | the plugin's own config fields |
 
-## Step 2 — Write the recipe (in a scratch directory)
+## Step 2 — Write the recipe
 
-Write the recipe outside the repo. The `source:` block comes from the reference;
-the rest is common:
+Write the recipe to `$WORKDIR/my_reco.yaml`. The `source:` block comes from the
+reference; the rest is common:
 
 ```yaml
 name: my_reco                      # becomes the /v1/recipes/{name}:* verb
@@ -122,7 +131,7 @@ training:
     test_user_ratio: 1.0
     seed: 42
 output:
-  path: /abs/path/scratch/my_reco.recotem
+  path: <WORKDIR>/my_reco.recotem  # a concrete absolute path; recipe files are NOT shell-expanded
   versioning: always_overwrite     # only always_overwrite | append_sha are valid
 ```
 
@@ -142,7 +151,7 @@ Recipe gotchas that bite the first time:
 ## Step 3 — Validate
 
 ```bash
-$R validate /abs/path/scratch/my_reco.yaml
+$R validate $WORKDIR/my_reco.yaml
 ```
 
 What `validate` checks depends on the source: BigQuery runs a free dry run (ADC
@@ -160,7 +169,7 @@ section of the source's reference. Keep the window small while iterating.
 ## Step 5 — Train
 
 ```bash
-$R train /abs/path/scratch/my_reco.yaml
+$R train $WORKDIR/my_reco.yaml
 ```
 
 **Watch the data shape, not just exit 0.** Collaborative filtering needs users
@@ -185,7 +194,7 @@ On success the log reports `train_done` with `best_class`, `best_score`, and
 ## Step 6 — Inspect the artifact
 
 ```bash
-$R inspect /abs/path/scratch/my_reco.recotem
+$R inspect $WORKDIR/my_reco.recotem
 ```
 
 Verifies the HMAC (`HMAC: OK`) and prints the header (`best_class`,
@@ -199,10 +208,10 @@ Do this when the user wants to see the recommend API return results.
 ```bash
 $R keygen --type api                      # note the plaintext AND the env_entry
 export RECOTEM_API_KEYS="<kid>:sha256:<hex64>"
-mkdir -p /abs/path/scratch/recipes
-cp /abs/path/scratch/my_reco.yaml /abs/path/scratch/recipes/   # serve scans *.yaml
+mkdir -p $WORKDIR/recipes
+cp $WORKDIR/my_reco.yaml $WORKDIR/recipes/   # serve scans *.yaml
 export RECOTEM_HOST=127.0.0.1 RECOTEM_PORT=8099
-$R serve --recipes /abs/path/scratch/recipes &
+$R serve --recipes $WORKDIR/recipes &
 ```
 
 The `--recipes` directory holds **recipe YAMLs**, not artifacts; serve reads each
@@ -228,6 +237,55 @@ Behaviors that confirm correct wiring: a scored `items` array on `200`; unknown
 user → `404 UNKNOWN_USER`; missing `X-API-Key` → `401 MISSING_API_KEY`. With
 `RECOTEM_API_KEYS` unset, serve binds to loopback and skips auth. Stop with
 `pkill -f "recotem serve"`.
+
+## Step 8 — Hand off the recommend API usage
+
+After the model is built, **always finish by printing a complete, copy-pasteable
+recommend API reference for the user**, with the placeholders filled in from
+what you actually used — recipe `name`, `$WORKDIR`, host/port, and a couple of
+**real** `user_id` / `item_id` values from the training data so the user can
+call it immediately. (Pull a few known IDs from the source if you do not already
+have them.) This is the deliverable; do not end with just "training done".
+
+Emit a block like this:
+
+```markdown
+### Recommend API — my_reco
+
+Start the server:
+    export RECOTEM_SIGNING_KEYS="<kid>:<hex64>"
+    export RECOTEM_API_KEYS="<kid>:sha256:<hex64>"   # omit to bind loopback with no auth
+    export RECOTEM_HOST=127.0.0.1 RECOTEM_PORT=8099
+    <recotem> serve --recipes <WORKDIR>/recipes
+
+Auth: send the API key plaintext in the `X-API-Key` header (none needed in
+loopback no-auth mode). Base URL: http://127.0.0.1:8099
+
+Health:
+    curl -s http://127.0.0.1:8099/v1/health
+
+User recommendations  (user_id must be one seen in training):
+    curl -s -X POST http://127.0.0.1:8099/v1/recipes/<name>:recommend \
+      -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+      -d '{"user_id": "<real known user>", "limit": 10, "exclude_items": []}'
+
+Related items  (no user; seed with known item_id values):
+    curl -s -X POST http://127.0.0.1:8099/v1/recipes/<name>:recommend-related \
+      -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+      -d '{"seed_items": ["<real known item>"], "limit": 10}'
+
+Response: {"request_id", "recipe", "model_version": "sha256:…",
+           "items": [{"item_id", "score"}, …]}
+
+Errors: 404 UNKNOWN_USER (user not in training) · 404 UNKNOWN_SEED_ITEMS ·
+        401 MISSING_API_KEY / INVALID_API_KEY · 503 RECIPE_UNAVAILABLE
+        (artifact not loaded). Stop the server: pkill -f "recotem serve".
+
+Known IDs to try — users: <id>, <id>  ·  items: <id>, <id>
+```
+
+Substitute the real recipe name, paths, port, and IDs; keep private identifiers
+in this on-screen handoff only (never commit them).
 
 ## Troubleshooting (exit codes and common failures)
 

--- a/.claude/skills/create-recommendation-model/references/bigquery.md
+++ b/.claude/skills/create-recommendation-model/references/bigquery.md
@@ -1,0 +1,109 @@
+# Source reference: BigQuery
+
+Use for interaction data in BigQuery — either a **GA4 export** (`events_*`
+date-sharded tables, the common case) or a **custom dataset/table** you own.
+
+## Authentication (ADC)
+
+recotem does not read credentials from the recipe; the Google client walks the
+standard Application Default Credentials chain. Confirm one is in place:
+
+```bash
+gcloud auth application-default login                 # local user creds, or
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json   # service account
+```
+
+The principal needs `roles/bigquery.jobUser` (project) +
+`roles/bigquery.dataViewer` (dataset). `source.project` is the **billing**
+project; when omitted the client uses the ADC ambient project.
+
+## Inputs to gather
+
+- Billing **project** and the **table** (`project.dataset.table`, or
+  `project.dataset.events_*` for GA4).
+- **Date range** to train on (keep short while iterating).
+- How each `schema` column is produced (see "Shaping item_id" below):
+  - `user_id` — GA4: `user_pseudo_id`. Custom: your user/customer key.
+  - `item_id` — what identifies an item and **how it is encoded**.
+  - `time_column` — GA4: `TIMESTAMP_MICROS(event_timestamp)`. Custom: your
+    timestamp column.
+- What counts as a positive interaction (GA4: which `event_name`; custom: which
+  rows).
+
+## `source:` block
+
+```yaml
+source:
+  type: bigquery
+  project: my-gcp-project            # or "${RECOTEM_RECIPE_GCP_PROJECT}" to keep it out of the file
+  query: |
+    SELECT
+      user_pseudo_id AS user_id,
+      <item_id expression> AS item_id,
+      TIMESTAMP_MICROS(event_timestamp) AS ts
+    FROM `my-project.analytics_XXXXXXXXX.events_*`
+    WHERE _TABLE_SUFFIX BETWEEN
+            FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL @lookback_days DAY))
+            AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+      AND event_name = 'page_view'
+  query_parameters:
+    lookback_days: 30                # int -> INT64; quote -> STRING. No dates/lists/null.
+```
+
+For a **custom table**, drop the GA4 specifics and select your columns directly:
+
+```yaml
+  query: |
+    SELECT customer_id AS user_id, product_id AS item_id, purchased_at AS ts
+    FROM `my-project.shop.purchases`
+    WHERE purchased_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @lookback_days DAY)
+```
+
+Use `@name` bind parameters for per-run values; `${...}` expansion is blocked
+inside the query.
+
+## Shaping `item_id` (extraction happens in SQL)
+
+GA4 has no single "item" — choose what to recommend:
+
+- **URL path** (works on raw GA4 with zero extra tagging; most portable):
+  ```sql
+  REGEXP_EXTRACT(
+    (SELECT value.string_value FROM UNNEST(event_params) WHERE key='page_location'),
+    r'^https?://[^/]+([^?#]*)')        -- path only
+  ```
+- **Stable ID embedded in the URL** — anchor on a delimiter so unrelated digits
+  (e.g. a `/2026/04/` date) are not matched:
+  ```sql
+  REGEXP_EXTRACT(page_location, r'/articles/(\d+)')          -- numeric ID after a segment
+  REGEXP_EXTRACT(page_location, r'[（(]([0-9A-Z]{4})[）)]')   -- 4-char alnum ID in parens
+  ```
+- **Custom event parameter** (requires GA4/GTM setup) — read it from
+  `event_params`, matching the value accessor to how it was sent
+  (`value.int_value` / `value.string_value`).
+
+Combine with `cleansing.drop_null_ids: true` so rows where `REGEXP_EXTRACT`
+returned NULL are dropped. See `docs/data-sources/bigquery.md` for the full GA4
+section.
+
+## Cost / volume
+
+`validate` runs a **free dry run**. recotem does not surface the byte estimate,
+so check it yourself before the real run (still free):
+
+```python
+# uv run python - <<'PY'
+from google.cloud import bigquery
+client = bigquery.Client(project="my-gcp-project")
+q = "<the exact query the recipe will run>"
+job = client.query(q, job_config=bigquery.QueryJobConfig(dry_run=True, use_query_cache=False))
+gb = job.total_bytes_processed / 1024**3
+print(f"scan {gb:.4f} GiB ~= ${gb/1024*6.25:.5f} on-demand")
+# PY
+```
+
+If larger than expected, shrink the date window or pre-aggregate. recotem does
+not set `maximum_bytes_billed`; add a project-level cost guard rail if runaway
+cost is a concern. GA4 `events_*` with `_TABLE_SUFFIX` bounds the scan to the
+selected day-shards — referencing `events_*` twice (e.g. a multi-interaction
+filter subquery) roughly doubles the scan.

--- a/.claude/skills/create-recommendation-model/references/files.md
+++ b/.claude/skills/create-recommendation-model/references/files.md
@@ -1,0 +1,72 @@
+# Source reference: CSV / Parquet files
+
+Use when interactions already exist as a file — a data export, a warehouse
+unload, or a hand-built table. Local paths and object stores
+(`s3://`, `gs://`, `az://`/`abfs://`/`abfss://`) are supported, plus
+`http(s)://` for CSV/Parquet.
+
+## Key difference from query sources
+
+There is **no query and no transform step**. The file must already contain the
+columns named in `schema` (`user_column`, `item_column`, and optionally
+`time_column`); recotem reads them by name. Any extraction (e.g. an ID out of a
+URL), filtering (which rows count as a positive), or aggregation must be done
+**upstream when the file is produced**. If you control the producing query, that
+is also where you would apply the "users with ≥2 distinct items" filter from
+Step 5.
+
+## Inputs to gather
+
+- **Path** and scheme (local / `s3://` / `gs://` / `az://` / `http(s)://`).
+- The **column names** in the file for user, item, and (optionally) time — these
+  go straight into `schema`.
+- CSV only: `delimiter`, `encoding`, header row index if non-standard.
+- For `http(s)://`: a **`sha256`** of the file is required, and the body is
+  capped by `RECOTEM_MAX_DOWNLOAD_BYTES` (default 256 MiB).
+
+## `source:` block
+
+CSV:
+
+```yaml
+source:
+  type: csv
+  path: /abs/path/interactions.csv     # or s3://bucket/key.csv, gs://..., https://...
+  delimiter: ","                       # optional (default ",")
+  encoding: "utf-8"                    # optional
+  # header: 0                          # optional row index of the header
+  # dtype: { item_id: str }            # optional per-column dtype hints
+  # sha256: "<64 hex>"                  # REQUIRED for http(s):// sources
+```
+
+Parquet:
+
+```yaml
+source:
+  type: parquet
+  path: /abs/path/interactions.parquet # or s3://..., gs://..., https://...
+  # sha256: "<64 hex>"                  # REQUIRED for http(s):// sources
+```
+
+Then map the file's own column names:
+
+```yaml
+schema:
+  user_column: user_id     # whatever the file calls them
+  item_column: item_id
+  time_column: ts          # omit if the file has no timestamp
+```
+
+Embedded URI credentials are rejected; configure object-store auth through the
+environment (fsspec / cloud SDK), not the path. Local `output.path` may be
+constrained to `RECOTEM_ARTIFACT_ROOT` if that is set.
+
+## Cost / volume
+
+There is no billing dry run. `validate` confirms the path exists and is
+readable. The practical limits are memory and download size: the whole file is
+read into a DataFrame, and `RECOTEM_MAX_DOWNLOAD_BYTES` caps the raw bytes for
+network/object-store reads (it does **not** cap the decompressed DataFrame).
+Keep an eye on row count for large exports; pre-aggregate upstream if needed.
+
+See `docs/data-sources/csv.md` for details.

--- a/.claude/skills/create-recommendation-model/references/sql.md
+++ b/.claude/skills/create-recommendation-model/references/sql.md
@@ -1,0 +1,61 @@
+# Source reference: SQL database
+
+Use for interactions in a relational database or warehouse reachable over a
+SQLAlchemy DSN — PostgreSQL, MySQL, or SQLite (each behind its own extra:
+`recotem[postgres]`, `recotem[mysql]`, `recotem[sqlite]`).
+
+## Credentials: DSN from an env var (not in the recipe)
+
+The recipe does **not** contain the DSN. It names an environment variable via
+`dsn_env`, and the variable name must match `^RECOTEM_RECIPE_[A-Z0-9_]+$`. This
+keeps the connection string (which usually embeds a password) out of the
+recipe file:
+
+```bash
+export RECOTEM_RECIPE_DB_DSN="postgresql://user:pass@host:5432/dbname"
+```
+
+By default the SQL source refuses private/loopback DSN hosts (an SSRF guard).
+Set `RECOTEM_SQL_ALLOW_PRIVATE=1` to allow a local/internal database — this also
+disables the DNS-rebinding re-check, so only opt in for hosts you trust.
+
+## Inputs to gather
+
+- Backend (postgres / mysql / sqlite) and the **DSN** (to put in the env var).
+- The **query** that returns user/item/[time] columns, and what counts as a
+  positive interaction.
+- Rough **row volume** for the window (see Cost / volume).
+
+## `source:` block
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN       # env var holding the DSN; name must match RECOTEM_RECIPE_*
+  query: |
+    SELECT customer_id AS user_id,
+           product_id  AS item_id,
+           purchased_at AS ts
+    FROM purchases
+    WHERE purchased_at >= :since
+  query_parameters:
+    since: "2026-05-01"                # str | int | float | bool
+  # connect_timeout_seconds: 10
+  # statement_timeout_seconds: 300
+```
+
+Bind values via the driver's parameter syntax (e.g. `:name`); `${...}`
+expansion is blocked inside `query` and `dsn_env`. Any `item_id` extraction uses
+your SQL dialect's functions (`SUBSTRING`, `REGEXP_SUBSTR`/`regexp_match`, etc.).
+The "users with ≥2 distinct items" filter from Step 5 goes in this query too.
+
+## Cost / volume
+
+No billing dry run; `validate` probes connectivity and the statement.
+`RECOTEM_MAX_SQL_ROWS` (default 50,000,000) hard-caps the returned **row count**
+— it does not bound resident DataFrame memory, so for very wide/large results
+pre-aggregate in SQL. `connect_timeout_seconds` / `statement_timeout_seconds`
+bound a slow or runaway query.
+
+See `docs/data-sources/sql.md` for the full reference, including the
+memory-bound caveat and the per-driver SSRF host forms.


### PR DESCRIPTION
## Summary

Adds a Claude Code skill that captures the end-to-end recotem model-creation workflow so it can be reused consistently, with the cost, privacy, and data-shape guard rails baked in.

Pipeline encoded by the skill:

**model interactions → choose source → write recipe → validate → estimate volume → train → inspect → (optional) serve + curl**

## Structure

```
.claude/skills/create-recommendation-model/
├── SKILL.md            source-agnostic workflow (238-line body)
└── references/
    ├── bigquery.md     GA4 export + custom datasets (ADC/IAM, item_id extraction, cost dry run)
    ├── files.md        CSV / Parquet (path/scheme, columns, sha256/size caps)
    └── sql.md          Postgres / MySQL / SQLite (DSN via env var, row caps, SSRF)
```

Per-source specifics live in `references/` so only the relevant one is loaded (progressive disclosure); the questions to ask the user genuinely differ by source.

## Design notes

- **Source-agnostic core.** Frames training data as implicit-feedback `(user, item, [time])` interactions, so it covers web/access logs, purchase logs, ratings, and plays — not just GA4. The user decides what counts as a positive.
- **Runtime selection.** Prefers an installed `recotem` (production-representative), falls back to `uv run recotem` from a source checkout, and forces the source path when verifying recotem's own code.
- **Guard rails as non-negotiables.** Validate (free dry run) before training; estimate scan/row volume first; keep secrets and private identifiers (project IDs, DSNs, keys, concrete user/item IDs) out of committed files — recipes go in a scratch dir, DSNs come from env vars, BigQuery `project` can use `${RECOTEM_RECIPE_*}`.
- **Lessons that bite once.** No recipe-level regex (extraction happens in the source query or upstream for files); `output.versioning` enum; query-parameter type inference; and the `zero_score` (exit 4) sparsity pitfall with the multi-interaction-user filter to avoid it.

## Compliance

Verified against the SKILL spec: required `name`/`description` frontmatter, `name` matches the directory and is kebab-case, body under 500 lines, each reference under 300 lines and linked from SKILL.md, imperative instructions that explain the rationale. Docs-only change; contains no secrets or private identifiers.