### PR TITLE
chore(pypi): add keywords and Trove classifiers for discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,36 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = { file = "LICENSE" }
 authors = [{ name = "CodeLibs, Inc.", email = "info@codelibs.co" }]
+keywords = [
+    "recommender-system",
+    "recommendation-system",
+    "recommendation-api",
+    "recommender",
+    "recsys",
+    "collaborative-filtering",
+    "matrix-factorization",
+    "implicit-feedback",
+    "personalization",
+    "ranking",
+    "irspack",
+    "optuna",
+    "machine-learning",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 dependencies = [
     "fastapi>=0.120,<0.140",


### PR DESCRIPTION
## What & why

Adds `keywords` and `classifiers` to the `[project]` table in `pyproject.toml`.
This is a metadata-only change that improves how PyPI categorizes the package
and strengthens the text signals search engines and LLM-based tools use to
associate Recotem with recommender-system terminology (recsys,
collaborative-filtering, implicit-feedback, recommendation-api).

`[project.urls]` (Homepage, Documentation, Repository, Issues, Changelog) were
already added in #138, so this PR does not touch them.

## Changes

- **`keywords`** (13): recommender-system, recommendation-system,
  recommendation-api, recommender, recsys, collaborative-filtering,
  matrix-factorization, implicit-feedback, personalization, ranking, irspack,
  optuna, machine-learning.
- **`classifiers`** (13): production status, `Environment :: Console`,
  `Framework :: FastAPI`, developer/research audiences, Apache-2.0 license,
  OS-independent, Python 3 / 3.12, and Scientific/Engineering + Library topics.

## Verification

- `pyproject.toml` parses; all 13 classifiers validated against the canonical
  `trove-classifiers` list.
- `uv build --wheel` succeeds and the built `METADATA` carries the `Keywords`
  line and all 13 `Classifier` entries.
- No source or behavior changes.